### PR TITLE
Beta 0.1.4

### DIFF
--- a/Assets/Material/BlockMaterial.mat
+++ b/Assets/Material/BlockMaterial.mat
@@ -11,14 +11,15 @@ Material:
   m_Shader: {fileID: -6465566751694194690, guid: d3cc742c925c7c240b4abc3430a9faab, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - _ALPHATEST_ON
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
+  m_CustomRenderQueue: 2450
   stringTagMap:
-    RenderType: Opaque
+    RenderType: TransparentCutout
   disabledShaderPasses:
   - MOTIONVECTORS
   - SHADOWCASTER
@@ -89,8 +90,8 @@ Material:
     m_Ints: []
     m_Floats:
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0
-    - _AlphaToMask: 0
+    - _AlphaClip: 1
+    - _AlphaToMask: 1
     - _Blend: 0
     - _BlendModePreserveSpecular: 1
     - _BlendOp: 0

--- a/Assets/Resources/hardcoded/models/item/player_head.json
+++ b/Assets/Resources/hardcoded/models/item/player_head.json
@@ -1,31 +1,31 @@
 {
 	"credit": "Made with Blockbench",
 	"textures": {
-		"1": "Downloads/92d64da8b8ad6710f33d4c30cd7b5e33ebeade90b222b03a691cfb2f289e6f48"
+		"particle": "texure"
 	},
 	"elements": [
 		{
 			"from": [4, 0, 4],
 			"to": [12, 8, 12],
 			"faces": {
-				"north": {"uv": [2, 2, 4, 4], "texture": "#1"},
-				"east": {"uv": [4, 2, 6, 4], "texture": "#1"},
-				"south": {"uv": [6, 2, 8, 4], "texture": "#1"},
-				"west": {"uv": [0, 2, 2, 4], "texture": "#1"},
-				"up": {"uv": [2, 0, 4, 2], "texture": "#1"},
-				"down": {"uv": [4, 0, 6, 2], "texture": "#1"}
+				"north": {"uv": [2, 2, 4, 4], "texture": "#particle"},
+				"east": {"uv": [0, 2, 2, 4], "texture": "#particle"},
+				"south": {"uv": [6, 2, 8, 4], "texture": "#particle"},
+				"west": {"uv": [4, 2, 6, 4], "texture": "#particle"},
+				"up": {"uv": [2, 0, 4, 2], "texture": "#particle"},
+				"down": {"uv": [4, 0, 6, 2], "texture": "#particle"}
 			}
 		},
 		{
 			"from": [3.5, -0.5, 3.5],
 			"to": [12.5, 8.5, 12.5],
 			"faces": {
-				"north": {"uv": [10, 2, 12, 4], "texture": "#1"},
-				"east": {"uv": [12, 2, 14, 4], "texture": "#1"},
-				"south": {"uv": [14, 2, 16, 4], "texture": "#1"},
-				"west": {"uv": [8, 2, 10, 4], "texture": "#1"},
-				"up": {"uv": [10, 0, 12, 2], "texture": "#1"},
-				"down": {"uv": [12, 0, 14, 2], "texture": "#1"}
+				"north": {"uv": [10, 2, 12, 4], "texture": "#particle"},
+				"east": {"uv": [12, 2, 14, 4], "texture": "#particle"},
+				"south": {"uv": [14, 2, 16, 4], "texture": "#particle"},
+				"west": {"uv": [8, 2, 10, 4], "texture": "#particle"},
+				"up": {"uv": [10, 0, 12, 2], "texture": "#particle"},
+				"down": {"uv": [12, 0, 14, 2], "texture": "#particle"}
 			}
 		}
 	]

--- a/Assets/Scripts/BDObject/BlockDisplay.cs
+++ b/Assets/Scripts/BDObject/BlockDisplay.cs
@@ -54,10 +54,12 @@ public class BlockDisplay : DisplayObject
                     }
                     else
                     {
-                        BlockModelGenerator newModel = Instantiate(modelElementParent, transform);
+                        BlockModelGenerator newModel = Instantiate(GameManager.GetManager<BDObjectManager>().blockPrefab, transform);
                         newModel.modelName = modelElementParent.modelName;
                         newModel.SetModelByBlockState(partObject["apply"]);
                     }
+
+                    //CustomLog.Log("Part : " + partObject["apply"].ToString());
                 }
             }
 

--- a/Assets/Scripts/BDObject/BlockModelGenerator.cs
+++ b/Assets/Scripts/BDObject/BlockModelGenerator.cs
@@ -132,11 +132,14 @@ public class BlockModelGenerator : MonoBehaviour
 
         bool IsTransparented = false;
 
-        ReadOnlySpan<string> NoTransparent = new[] { "bed", "fire", "banner" };
+        ReadOnlySpan<string> NoTransparent = new[] { "bed", "banner", "head", "fire" };
         for (int i = 0; i < NoTransparent.Length; i++)
         {
             if (modelName.Contains(NoTransparent[i]))
+            {
                 IsTransparented = true;
+                break;
+            }
         }
 
         // 각 면을 채우기
@@ -163,7 +166,7 @@ public class BlockModelGenerator : MonoBehaviour
                     // 모든 재질 변경하기
                     var cubeMaterials = cubeObject.materials;
                     int cnt = cubeObject.materials.Length;
-                    Material tshader = GameManager.GetManager<BDObjectManager>().GetBDObjMaterial(this);
+                    Material tshader = GameManager.GetManager<BDObjectManager>().BDObjTransportMaterial;
 
                     for (int i = 0; i < cnt; i++)
                     {

--- a/Assets/Scripts/BDObject/HeadGenerator.cs
+++ b/Assets/Scripts/BDObject/HeadGenerator.cs
@@ -26,6 +26,8 @@ public class HeadGenerator : BlockModelGenerator
 
     public void GenerateHead(string name)
     {
+        modelName = "head";
+
         headType = name switch
         {
             "player" => HeadType.PLAYER,

--- a/Assets/Scripts/BDObject/ItemDisplay.cs
+++ b/Assets/Scripts/BDObject/ItemDisplay.cs
@@ -79,7 +79,6 @@ public class ItemDisplay : DisplayObject
 
     private void GenerateUsingBlockModel(string model, Color co)
     {
-        //CustomLog.Log("Block Model: " + model);
         var bd = Instantiate(GameManager.GetManager<BDObjectManager>().blockPrefab, transform);
         bd.modelName = model;
         bd.color = co;
@@ -151,6 +150,7 @@ public class ItemDisplay : DisplayObject
                     "block/" + specialModel["type"].ToString(),
                     MinecraftColorExtensions.ToColorEnum(specialModel["color"].ToString()).ToColor()
                     );
+
                 break;
             case "minecraft:head":
                 var head = Instantiate(GameManager.GetManager<BDObjectManager>().headPrefab, transform);

--- a/Assets/Scripts/Manager/BDObjectManager.cs
+++ b/Assets/Scripts/Manager/BDObjectManager.cs
@@ -49,18 +49,6 @@ public class BDObjectManager : RootManager
         }
     }
 
-    public Material GetBDObjMaterial(BlockModelGenerator model)
-    {
-        if (model is HeadGenerator)
-        {
-            return BDObjHeadMaterial;
-        }
-        else
-        {
-            return BDObjTransportMaterial;
-        }
-    }
-
     public void ClearAllObject()
     {
         Destroy(BDObjectParent.gameObject);

--- a/Assets/Scripts/Manager/SystemManager.cs
+++ b/Assets/Scripts/Manager/SystemManager.cs
@@ -7,6 +7,14 @@ public class SystemManager : RootManager
 {
     public string[] filesDropped;
 
+
+    private float deltaTime = 0f;
+
+    [SerializeField] private int size = 15;
+    [SerializeField] private Color color = Color.white;
+
+    GUIStyle style;
+
     protected override void Awake()
     {
         base.Awake();
@@ -17,25 +25,30 @@ public class SystemManager : RootManager
         //UnityDragAndDropHook.OnDroppedFiles += OnFiles;
     }
 
-    private float deltaTime = 0f;
-
-    [SerializeField] private int size = 20;
-    [SerializeField] private Color color = Color.red;
-
-    private void OnGUI()
+    private void Start()
     {
-        GUIStyle style = new GUIStyle();
+        style = new GUIStyle();
 
-        Rect rect = new Rect(10, 10, Screen.width, Screen.height);
         style.alignment = TextAnchor.UpperLeft;
         style.fontSize = size;
         style.normal.textColor = color;
+    }
+
+    private void OnGUI()
+    {
+
+
+        Rect rect = new Rect(10, 30, Screen.width, Screen.height);
 
         float ms = deltaTime * 1000f;
         float fps = 1.0f / deltaTime;
         string text = string.Format("{0:0.} FPS ({1:0.0} ms)", fps, ms);
+        
+        Rect versionRect = new Rect(10, 10, Screen.width, Screen.height);
+        string version = string.Format("Version: {0}", Application.version);
 
         GUI.Label(rect, text, style);
+        GUI.Label(versionRect, version, style);
     }
 
     //private void OnDestroy()
@@ -60,7 +73,7 @@ public class SystemManager : RootManager
             {
                 string clipboard = GUIUtility.systemCopyBuffer;
 
-                //CustomLog.Log("Clipboard: " + clipboard);
+                CustomLog.Log("Clipboard: " + clipboard);
 
                 GameManager.GetManager<FileManager>().MakeDisplay(clipboard);
             }

--- a/Assets/Scripts/Minecraft/MinecraftColor.cs
+++ b/Assets/Scripts/Minecraft/MinecraftColor.cs
@@ -9,22 +9,22 @@ namespace Minecraft.MColor
     /// </summary>
     public enum MinecraftColor
     {
-        Black,
-        DarkBlue,
-        DarkGreen,
-        DarkAqua,
-        DarkRed,
-        DarkPurple,
-        Gold,
-        Gray,
-        DarkGray,
-        Blue,
-        Green,
-        Aqua,
-        Red,
-        LightPurple,
+        White,
+        Orange,
+        Magenta,
+        LightBlue,
         Yellow,
-        White
+        Lime,
+        Pink,
+        Gray,
+        LightGray,
+        Cyan,
+        Purple,
+        Blue,
+        Brown,
+        Green,
+        Red,
+        Black
     }
 
     /// <summary>
@@ -32,23 +32,24 @@ namespace Minecraft.MColor
     /// </summary>
     public static class MinecraftColors
     {
-        public static readonly Color Black = new Color32(0, 0, 0, 255);
-        public static readonly Color DarkBlue = new Color32(0, 0, 170, 255);
-        public static readonly Color DarkGreen = new Color32(0, 170, 0, 255);
-        public static readonly Color DarkAqua = new Color32(0, 170, 170, 255);
-        public static readonly Color DarkRed = new Color32(170, 0, 0, 255);
-        public static readonly Color DarkPurple = new Color32(170, 0, 170, 255);
-        public static readonly Color Gold = new Color32(255, 170, 0, 255);
-        public static readonly Color Gray = new Color32(170, 170, 170, 255);
-        public static readonly Color DarkGray = new Color32(85, 85, 85, 255);
-        public static readonly Color Blue = new Color32(85, 85, 255, 255);
-        public static readonly Color Green = new Color32(85, 255, 85, 255);
-        public static readonly Color Aqua = new Color32(85, 255, 255, 255);
-        public static readonly Color Red = new Color32(255, 85, 85, 255);
-        public static readonly Color LightPurple = new Color32(255, 85, 255, 255);
-        public static readonly Color Yellow = new Color32(255, 255, 85, 255);
-        public static readonly Color White = new Color32(255, 255, 255, 255);
+        public static readonly Color White = new Color32(249, 255, 254, 255);   // #F9FFFE
+        public static readonly Color Orange = new Color32(249, 128, 29, 255);   // #F9801D
+        public static readonly Color Magenta = new Color32(199, 74, 189, 255);  // #C74EBD
+        public static readonly Color LightBlue = new Color32(58, 183, 212, 255);// #3ABBD4
+        public static readonly Color Yellow = new Color32(254, 219, 61, 255);   // #FEDB3D
+        public static readonly Color Lime = new Color32(128, 199, 71, 255);     // #80C71F
+        public static readonly Color Pink = new Color32(243, 139, 170, 255);    // #F38BAA
+        public static readonly Color Gray = new Color32(71, 71, 75, 255);       // #474F52
+        public static readonly Color LightGray = new Color32(144, 144, 157, 255); // #909D97
+        public static readonly Color Cyan = new Color32(22, 156, 156, 255);     // #169C9C
+        public static readonly Color Purple = new Color32(137, 58, 168, 255);   // #893A8A
+        public static readonly Color Blue = new Color32(60, 68, 170, 255);      // #3C44AA
+        public static readonly Color Brown = new Color32(131, 84, 50, 255);     // #835432
+        public static readonly Color Green = new Color32(94, 124, 22, 255);     // #5E7C16
+        public static readonly Color Red = new Color32(176, 46, 38, 255);       // #B02E26
+        public static readonly Color Black = new Color32(17, 17, 21, 255);      // #1D1D21
     }
+
 
 
 
@@ -59,22 +60,22 @@ namespace Minecraft.MColor
     {
         private static readonly Dictionary<string, MinecraftColor> colorMap = new Dictionary<string, MinecraftColor>(StringComparer.OrdinalIgnoreCase)
     {
-        { "black", MinecraftColor.Black },
-        { "dark_blue", MinecraftColor.DarkBlue },
-        { "dark_green", MinecraftColor.DarkGreen },
-        { "dark_aqua", MinecraftColor.DarkAqua },
-        { "dark_red", MinecraftColor.DarkRed },
-        { "dark_purple", MinecraftColor.DarkPurple },
-        { "gold", MinecraftColor.Gold },
-        { "gray", MinecraftColor.Gray },
-        { "dark_gray", MinecraftColor.DarkGray },
-        { "blue", MinecraftColor.Blue },
-        { "green", MinecraftColor.Green },
-        { "aqua", MinecraftColor.Aqua },
-        { "red", MinecraftColor.Red },
-        { "light_purple", MinecraftColor.LightPurple },
-        { "yellow", MinecraftColor.Yellow },
-        { "white", MinecraftColor.White }
+            { "white", MinecraftColor.White },
+            { "orange", MinecraftColor.Orange },
+            { "magenta", MinecraftColor.Magenta },
+            { "light_blue", MinecraftColor.LightBlue },
+            { "yellow", MinecraftColor.Yellow },
+            { "lime", MinecraftColor.Lime },
+            { "pink", MinecraftColor.Pink },
+            { "gray", MinecraftColor.Gray },
+            { "light_gray", MinecraftColor.LightGray },
+            { "cyan", MinecraftColor.Cyan },
+            { "purple", MinecraftColor.Purple },
+            { "blue", MinecraftColor.Blue },
+            { "brown", MinecraftColor.Brown },
+            { "green", MinecraftColor.Green },
+            { "red", MinecraftColor.Red },
+            { "black", MinecraftColor.Black }
     };
 
         public static MinecraftColor ToColorEnum(string mcColor)
@@ -90,22 +91,22 @@ namespace Minecraft.MColor
         {
             return mcColor switch
             {
-                MinecraftColor.Black => MinecraftColors.Black,
-                MinecraftColor.DarkBlue => MinecraftColors.DarkBlue,
-                MinecraftColor.DarkGreen => MinecraftColors.DarkGreen,
-                MinecraftColor.DarkAqua => MinecraftColors.DarkAqua,
-                MinecraftColor.DarkRed => MinecraftColors.DarkRed,
-                MinecraftColor.DarkPurple => MinecraftColors.DarkPurple,
-                MinecraftColor.Gold => MinecraftColors.Gold,
-                MinecraftColor.Gray => MinecraftColors.Gray,
-                MinecraftColor.DarkGray => MinecraftColors.DarkGray,
-                MinecraftColor.Blue => MinecraftColors.Blue,
-                MinecraftColor.Green => MinecraftColors.Green,
-                MinecraftColor.Aqua => MinecraftColors.Aqua,
-                MinecraftColor.Red => MinecraftColors.Red,
-                MinecraftColor.LightPurple => MinecraftColors.LightPurple,
-                MinecraftColor.Yellow => MinecraftColors.Yellow,
                 MinecraftColor.White => MinecraftColors.White,
+                MinecraftColor.Orange => MinecraftColors.Orange,
+                MinecraftColor.Magenta => MinecraftColors.Magenta,
+                MinecraftColor.LightBlue => MinecraftColors.LightBlue,
+                MinecraftColor.Yellow => MinecraftColors.Yellow,
+                MinecraftColor.Lime => MinecraftColors.Lime,
+                MinecraftColor.Pink => MinecraftColors.Pink,
+                MinecraftColor.Gray => MinecraftColors.Gray,
+                MinecraftColor.LightGray => MinecraftColors.LightGray,
+                MinecraftColor.Cyan => MinecraftColors.Cyan,
+                MinecraftColor.Purple => MinecraftColors.Purple,
+                MinecraftColor.Blue => MinecraftColors.Blue,
+                MinecraftColor.Brown => MinecraftColors.Brown,
+                MinecraftColor.Green => MinecraftColors.Green,
+                MinecraftColor.Red => MinecraftColors.Red,
+                MinecraftColor.Black => MinecraftColors.Black,
                 _ => MinecraftColors.Black // 기본값 (예외 방지)
             };
         }

--- a/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,28 +33,28 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 6292376818734858405
-      - rid: 6292376818734858406
+      - rid: 6292376823043719308
+      - rid: 6292376823043719309
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 6292376818734858407
-      - rid: 6292376818734858408
+      - rid: 6292376823043719310
+      - rid: 6292376823043719311
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 6292376818734858409
-      - rid: 6292376818734858410
-      - rid: 6292376818734858411
-      - rid: 6292376818734858412
-      - rid: 6292376818734858413
-      - rid: 6292376818734858414
+      - rid: 6292376823043719312
+      - rid: 6292376823043719313
+      - rid: 6292376823043719314
+      - rid: 6292376823043719315
+      - rid: 6292376823043719316
+      - rid: 6292376823043719317
       - rid: 6852985685364965392
-      - rid: 6292376818734858415
+      - rid: 6292376823043719318
       - rid: 6852985685364965394
       - rid: 8712630790384254976
       - rid: 8616716036708499456
-      - rid: 6292376818734858416
+      - rid: 6292376823043719319
     m_RuntimeSettings:
       m_List:
       - rid: 6852985685364965378
@@ -97,14 +97,14 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 6292376818734858405
+    - rid: 6292376823043719308
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 1
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 6292376818734858406
+    - rid: 6292376823043719309
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -116,7 +116,7 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 6292376818734858407
+    - rid: 6292376823043719310
       type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -131,7 +131,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 6292376818734858408
+    - rid: 6292376823043719311
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -140,7 +140,7 @@ MonoBehaviour:
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
         m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-    - rid: 6292376818734858409
+    - rid: 6292376823043719312
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -153,13 +153,13 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 6292376818734858410
+    - rid: 6292376823043719313
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 6292376818734858411
+    - rid: 6292376823043719314
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -172,12 +172,12 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 6292376818734858412
+    - rid: 6292376823043719315
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 6292376818734858413
+    - rid: 6292376823043719316
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -187,21 +187,21 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 6292376818734858414
+    - rid: 6292376823043719317
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 6292376818734858415
+    - rid: 6292376823043719318
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
         probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
         probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
-    - rid: 6292376818734858416
+    - rid: 6292376823043719319
       type: {class: UniversalRenderPipelineEditorAssets, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultSettingsVolumeProfile: {fileID: 11400000, guid: eda47df5b85f4f249abf7abd73db2cb2, type: 2}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -142,7 +142,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.1.1
+  bundleVersion: 0.1.4
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
   metroInputSource: 0


### PR DESCRIPTION
머리 UV 잘못되었던 버그 수정
버전 정보 표시 추가
색이 마크 코드 정보에 맞춰져 있고 마크 기본 16색과 맞지 않아 배너가 제대로 구현되지 않은 점 수정 multipart가 각각의 part가 아니라 복제되어 여러개가 나오는 버그 수정
이제 모든 불투명 물체는 alpha clipping을 사용함